### PR TITLE
Ensure enumeration values are rendered correctly

### DIFF
--- a/core/src/main/resources/flexmi2plantuml.egl
+++ b/core/src/main/resources/flexmi2plantuml.egl
@@ -12,7 +12,7 @@ var colors = getColors();
 
 [%for (e in elements) { %]
 object "[%=e.getNodeLabel()%]" as [%=e.getNodeId()%] #[%=colors.get(e.eClass().eContainer().eContents().indexOf(e.eClass()).mod(colors.size()))%] {
-	[%var attributes = e.eClass().getEAllAttributes().select(attr|e.eIsSet(attr));%]
+	[%var attributes = e.eClass().getEAllAttributes().select(attr|e.eIsSet(attr) or not attr.isUnsettable());%]
 	[%for (attr in attributes){%]
 	[%=attr.name%] = [%=e.getAttributeValue(attr)%]
 	[%}%]


### PR DESCRIPTION
This works around a bug in EMF, where enumeration attributes that hold the default value are reported as unset (even though by default enumeration attributes are set to not be unsettable).